### PR TITLE
refactor: Excel 직렬화/역직렬화 기능 분리 및 버전 업데이트

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.jeng832</groupId>
     <artifactId>poibox</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0-candidate</version>
 
     <name>poibox</name>
     <description>POI-Box is a Java library that easily converts Excel files into Java objects using Apache POI.</description>

--- a/src/main/java/io/github/jeng832/converter/ExcelConverter.java
+++ b/src/main/java/io/github/jeng832/converter/ExcelConverter.java
@@ -5,14 +5,14 @@ import io.github.jeng832.exception.ExcelConvertException;
 import java.util.List;
 
 /**
- * @deprecated This class is replaced by {@link io.github.jeng832.serializer.ExcelSerializer}
+ * @deprecated This class is replaced by {@link io.github.jeng832.deserializer.ExcelDeserializer}
  */
 @Deprecated
 public interface ExcelConverter {
 
     /**
      * This method is convert Excel file to objects.
-     * @deprecated This method is replaced by {@link io.github.jeng832.serializer.ExcelSerializer#serialize(Class)}
+     * @deprecated This method is replaced by {@link io.github.jeng832.deserializer.ExcelDeserializer#deserialize(Class)}
      */
     @Deprecated
     <T> List<T> toObjects(Class<T> clazz) throws ExcelConvertException;

--- a/src/main/java/io/github/jeng832/converter/ExcelConverterBuilderImpl.java
+++ b/src/main/java/io/github/jeng832/converter/ExcelConverterBuilderImpl.java
@@ -5,6 +5,7 @@ import io.github.jeng832.deserializer.ExcelDeserializerImpl;
 import io.github.jeng832.exception.ExcelConvertException;
 import io.github.jeng832.serializer.ExcelSerializer;
 import io.github.jeng832.serializer.ExcelSerializerImpl;
+
 import org.apache.poi.ss.util.CellAddress;
 
 class ExcelConverterBuilderImpl implements ExcelConverterBuilder {

--- a/src/main/java/io/github/jeng832/converter/ExcelConverterImpl.java
+++ b/src/main/java/io/github/jeng832/converter/ExcelConverterImpl.java
@@ -18,7 +18,7 @@ import java.time.ZonedDateTime;
 import java.util.*;
 
 /**
- * @deprecated This class is replaced by {@link io.github.jeng832.serializer.ExcelSerializerImpl}
+ * @deprecated This class is replaced by {@link io.github.jeng832.deserializer.ExcelDeserializerImpl}
  */
 @Deprecated
 class ExcelConverterImpl implements ExcelConverter {

--- a/src/main/java/io/github/jeng832/deserializer/ExcelDeserializerImpl.java
+++ b/src/main/java/io/github/jeng832/deserializer/ExcelDeserializerImpl.java
@@ -1,19 +1,241 @@
 package io.github.jeng832.deserializer;
 
+import io.github.jeng832.annotation.ExcelProperty;
 import io.github.jeng832.converter.ExcelConverterBuilder;
+import io.github.jeng832.converter.HeaderDirection;
 import io.github.jeng832.exception.ExcelConvertException;
+import io.github.jeng832.exception.ExceptionMessages;
+import io.github.jeng832.model.Excel;
+import io.github.jeng832.model.ExcelPropertyMap;
+import io.github.jeng832.model.ExcelSheet;
+import org.apache.poi.ss.util.CellAddress;
 
-import java.util.Collections;
-import java.util.List;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
 
 public class ExcelDeserializerImpl implements ExcelDeserializer {
 
-    public ExcelDeserializerImpl(ExcelConverterBuilder excelConverterBuilder) {
-        // TODO
+    private final ExcelSheet sheet;
+    private final boolean hasHeader;
+    private final HeaderDirection headerDirection;
+    private final CellAddress headerStartCell;
+    private final CellAddress headerEndCell;
+    private final CellAddress contentsStartCell;
+    private final int linesOfUnit;
+
+    public ExcelDeserializerImpl(ExcelConverterBuilder builder) throws ExcelConvertException {
+        if (builder.getExcelFilePath() == null || builder.getExcelFilePath().isEmpty()) {
+            throw new ExcelConvertException(ExceptionMessages.EXCEL_CONVERT_EXCEPTION_FILE_PATH_NOT_EXIST);
+        }
+        if (builder.getSheetName() == null || builder.getSheetName().isEmpty()) {
+            throw new ExcelConvertException(ExceptionMessages.EXCEL_CONVERT_EXCEPTION_SHEET_NOT_EXIST);
+        }
+        if (builder.hasHeader()) {
+            this.sheet = Excel.of(builder.getExcelFilePath())
+                    .getSheetWithHeader(builder.getSheetName(), builder.getHeaderStartCell(), builder.getHeaderEndCell());
+        } else {
+            this.sheet = Excel.of(builder.getExcelFilePath()).getSheet(builder.getSheetName());
+        }
+        this.hasHeader = builder.hasHeader();
+        this.headerDirection = builder.getHeaderDirection();
+        this.headerStartCell = new CellAddress(builder.getHeaderStartCell());
+        this.headerEndCell = new CellAddress(builder.getHeaderEndCell());
+        this.linesOfUnit = (builder.getLinesOfUnit() != null) ? builder.getLinesOfUnit() : sheet.getHeaderHeight();
+        if (this.sheet.getHeaderHeight() != this.linesOfUnit) {
+            throw new ExcelConvertException("The lines of the content unit must be same with the height of the header");
+        }
+        this.contentsStartCell = (builder.getContentsStartCell() != null) ?
+                new CellAddress(builder.getContentsStartCell()) :
+                (headerEndCell != null) ? new CellAddress(headerEndCell.getRow() + 1, headerStartCell.getColumn()) : new CellAddress(headerStartCell.getRow() + 1, headerStartCell.getColumn());
     }
 
     @Override
     public <T> List<T> deserialize(Class<T> clazz) throws ExcelConvertException {
-        return Collections.emptyList();
+        ExcelPropertyMap excelPropertyMap = new ExcelPropertyMap();
+        for (Field field : clazz.getDeclaredFields()) {
+            if (field.isAnnotationPresent(ExcelProperty.class)) {
+                ExcelProperty excelProperty = field.getAnnotation(ExcelProperty.class);
+
+                String setterName = "set" + field.getName().substring(0, 1).toUpperCase() + field.getName().substring(1);
+                Method setter;
+                try {
+                    setter = clazz.getDeclaredMethod(setterName, field.getType());
+                } catch (NoSuchMethodException e) {
+                    setter = null;
+                }
+                excelPropertyMap.add(field, excelProperty.value(), setter);
+            }
+        }
+
+        int contentStartRow = this.contentsStartCell.getRow();
+        int contentEndRow = sheet.getLastNonEmptyRowNumber();
+        int contentStartCol = this.contentsStartCell.getColumn();
+
+        List<T> objects = new ArrayList<>();
+        for (int i = contentStartRow; i <= contentEndRow - linesOfUnit + 1; i += linesOfUnit) {
+            T object;
+            try {
+                object = clazz.getDeclaredConstructor().newInstance();
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException |
+                     NoSuchMethodException e) {
+                throw new ExcelConvertException(ExceptionMessages.EXCEL_CONVERT_EXCEPTION_CANNOT_CONSTRUCT_OBJECT , e);
+            }
+            for (int j = 0; j < sheet.getHeaderHeight(); j++) {
+                for (int k = 0; k < sheet.getHeaderWidth(); k++) {
+                    CellAddress cellAddress = new CellAddress(i + j, contentStartCol + k);
+
+                    String headerValue = sheet.getHeaderValue(j, k);
+                    Set<Field> fields = excelPropertyMap.getFields();
+                    for (Field field : fields) {
+                        String value = excelPropertyMap.getValue(field).orElse(null);
+                        if (headerValue != null && headerValue.equals(value)) {
+                            Optional<Method> optSetter = excelPropertyMap.getSetter(field);
+                            if (optSetter.isPresent()) {
+                                Method setter = optSetter.get();
+                                setValue(object, setter, cellAddress);
+                            } else {
+                                setValue(object, field, cellAddress);
+                            }
+                        }
+                    }
+                }
+            }
+
+            objects.add(object);
+        }
+
+        return objects;
     }
+
+    private <T> void setValue(T object, Method setter, CellAddress cellAddress) throws ExcelConvertException {
+        Class<?>[] parameterTypes = setter.getParameterTypes();
+        Class<?> parameterType = parameterTypes[0];
+        if (sheet.isFormulaCell(cellAddress)) {
+            if (parameterType.equals(String.class) && sheet.isStringFormulaCell(cellAddress)) {
+                invokeSetter(setter, object, sheet.getValueAsString(cellAddress));
+            } else if (sheet.isDateFormulaCell(cellAddress)) {
+                if (parameterType.equals(Date.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDate(cellAddress));
+                } else if (parameterType.equals(LocalDate.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+                } else if (parameterType.equals(LocalDateTime.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+                } else if (parameterType.equals(ZonedDateTime.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()));
+                }
+            } else if (sheet.isNumberFormulaCell(cellAddress)) {
+                if (parameterType.equals(Double.TYPE) || parameterType.equals(Double.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDouble(cellAddress));
+                } else if (parameterType.equals(Float.TYPE) || parameterType.equals(Float.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsDouble(cellAddress).floatValue());
+                } else if (parameterType.equals(Integer.TYPE) || parameterType.equals(Integer.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsInteger(cellAddress));
+                } else if (parameterType.equals(Long.TYPE) || parameterType.equals(Long.class)) {
+                    invokeSetter(setter, object, sheet.getValueAsLong(cellAddress));
+                }
+            }
+        } else if (sheet.isStringCell(cellAddress)) {
+            invokeSetter(setter, object, sheet.getValueAsString(cellAddress));
+        } else if (sheet.isDateCell(cellAddress)) {
+            if (parameterType.equals(Date.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDate(cellAddress));
+            } else if (parameterType.equals(LocalDate.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            } else if (parameterType.equals(LocalDateTime.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+            } else if (parameterType.equals(ZonedDateTime.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()));
+            }
+        } else if (sheet.isNumberCell(cellAddress)) {
+            if (parameterType.equals(Double.TYPE) || parameterType.equals(Double.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDouble(cellAddress));
+            } else if (parameterType.equals(Float.TYPE) || parameterType.equals(Float.class)) {
+                invokeSetter(setter, object, sheet.getValueAsDouble(cellAddress).floatValue());
+            } else if (parameterType.equals(Integer.TYPE) || parameterType.equals(Integer.class)) {
+                invokeSetter(setter, object, sheet.getValueAsInteger(cellAddress));
+            } else if (parameterType.equals(Long.TYPE) || parameterType.equals(Long.class)) {
+                invokeSetter(setter, object, sheet.getValueAsLong(cellAddress));
+            }
+        } else if (sheet.isBooleanCell(cellAddress)) {
+            invokeSetter(setter, object, sheet.getValueAsBoolean(cellAddress));
+        }
+    }
+
+    private void invokeSetter(Method setter, Object object, Object value) throws ExcelConvertException {
+        try {
+            setter.invoke(object, value);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new ExcelConvertException(ExceptionMessages.EXCEL_CONVERT_EXCEPTION_CANNOT_SET_VALUE, e);
+        }
+    }
+
+    private <T> void setValue(T object, Field field, CellAddress cellAddress) throws ExcelConvertException {
+        field.setAccessible(true);
+        Class<?> fieldType = field.getType();
+        if (sheet.isFormulaCell(cellAddress)) {
+            if (fieldType.equals(String.class) && sheet.isStringFormulaCell(cellAddress)) {
+                setValue(field, object, sheet.getValueAsString(cellAddress));
+            } else if (sheet.isDateFormulaCell(cellAddress)) {
+                if (fieldType.equals(Date.class)) {
+                    setValue(field, object, sheet.getValueAsDate(cellAddress));
+                } else if (fieldType.equals(LocalDate.class)) {
+                    setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+                } else if (fieldType.equals(LocalDateTime.class)) {
+                    setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+                } else if (fieldType.equals(ZonedDateTime.class)) {
+                    setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()));
+                }
+            } else if (sheet.isNumberFormulaCell(cellAddress)) {
+                if (fieldType.equals(Double.TYPE) || fieldType.equals(Double.class)) {
+                    setValue(field, object, sheet.getValueAsDouble(cellAddress));
+                } else if (fieldType.equals(Float.TYPE) || fieldType.equals(Float.class)) {
+                    setValue(field, object, sheet.getValueAsDouble(cellAddress).floatValue());
+                } else if (fieldType.equals(Integer.TYPE) || fieldType.equals(Integer.class)) {
+                    setValue(field, object, sheet.getValueAsInteger(cellAddress));
+                } else if (fieldType.equals(Long.TYPE) || fieldType.equals(Long.class)) {
+                    setValue(field, object, sheet.getValueAsLong(cellAddress));
+                }
+            }
+        } else if (sheet.isStringCell(cellAddress)) {
+            setValue(field, object, sheet.getValueAsString(cellAddress));
+        } else if(sheet.isDateCell(cellAddress)) {
+            if (fieldType.equals(Date.class)) {
+                setValue(field, object, sheet.getValueAsDate(cellAddress));
+            } else if (fieldType.equals(LocalDate.class)) {
+                setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDate());
+            } else if (fieldType.equals(LocalDateTime.class)) {
+                setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
+            } else if (fieldType.equals(ZonedDateTime.class)) {
+                setValue(field, object, sheet.getValueAsDate(cellAddress).toInstant().atZone(ZoneId.systemDefault()));
+            }
+
+        } else if (sheet.isNumberCell(cellAddress)) {
+            if (fieldType.equals(Double.TYPE) || fieldType.equals(Double.class)) {
+                setValue(field, object, sheet.getValueAsDouble(cellAddress));
+            } else if (fieldType.equals(Float.TYPE) || fieldType.equals(Float.class)) {
+                setValue(field, object, sheet.getValueAsDouble(cellAddress).floatValue());
+            } else if (fieldType.equals(Integer.TYPE) || fieldType.equals(Integer.class)) {
+                setValue(field, object, sheet.getValueAsInteger(cellAddress));
+            } else if (fieldType.equals(Long.TYPE) || fieldType.equals(Long.class)) {
+                setValue(field, object, sheet.getValueAsLong(cellAddress));
+            }
+        } else if (sheet.isBooleanCell(cellAddress)) {
+            setValue(field, object, sheet.getValueAsBoolean(cellAddress));
+        }
+    }
+
+    private void setValue(Field field, Object object, Object value) throws ExcelConvertException {
+        try {
+            field.set(object, value);
+        } catch (IllegalAccessException e) {
+            throw new ExcelConvertException(ExceptionMessages.EXCEL_CONVERT_EXCEPTION_CANNOT_SET_VALUE, e);
+        }
+    }
+
 }

--- a/src/main/java/io/github/jeng832/exception/ExceptionMessages.java
+++ b/src/main/java/io/github/jeng832/exception/ExceptionMessages.java
@@ -7,4 +7,5 @@ public class ExceptionMessages {
     public static final String EXCEL_CONVERT_EXCEPTION_CANNOT_LOAD_FILE = "Cannot load the file";
     public static final String EXCEL_CONVERT_EXCEPTION_CANNOT_CONSTRUCT_OBJECT = "Cannot construct the object";
     public static final String EXCEL_CONVERT_EXCEPTION_CANNOT_SET_VALUE = "Cannot set the value";
+    public static final String EXCEL_CONVERT_EXCEPTION_CANNOT_WRITE_FILE = "Cannot write the file";
 }

--- a/src/main/java/io/github/jeng832/serializer/ExcelSerializer.java
+++ b/src/main/java/io/github/jeng832/serializer/ExcelSerializer.java
@@ -6,5 +6,12 @@ import java.util.List;
 
 public interface ExcelSerializer {
 
-    <T> List<T> serialize(Class<T> clazz) throws ExcelConvertException;
+    /**
+     * Java 객체를 Excel 파일로 변환합니다.
+     * @param objects 변환할 Java 객체 목록
+     * @param clazz 객체의 클래스 타입
+     * @param <T> 객체의 타입
+     * @throws ExcelConvertException 변환 중 오류가 발생한 경우
+     */
+    <T> void serialize(List<T> objects, Class<T> clazz) throws ExcelConvertException;
 }

--- a/src/test/java/io/github/jeng832/converter/ExcelDeserializerTest.java
+++ b/src/test/java/io/github/jeng832/converter/ExcelDeserializerTest.java
@@ -1,8 +1,9 @@
 package io.github.jeng832.converter;
 
+import io.github.jeng832.deserializer.ExcelDeserializer;
 import io.github.jeng832.exception.ExcelConvertException;
 import io.github.jeng832.model.*;
-import io.github.jeng832.serializer.ExcelSerializer;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -12,22 +13,22 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-class ExcelSerializerTest {
+class ExcelDeserializerTest {
 
     @Test
     public void convert_without_setter() throws ExcelConvertException {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("시트1")
                 .hasHeader(true)
                 .headerStartCell("A1")
                 .headerEndCell("G1")
-                .buildSerializer();
+                .buildDeserializer();
 
-        List<NoSetterTestClass> objects = serializer.serialize(NoSetterTestClass.class);
+        List<NoSetterTestClass> objects = deserializer.deserialize(NoSetterTestClass.class);
         assertNotNull(objects);
         Assertions.assertEquals(4, objects.size());
         System.out.println(objects);
@@ -38,19 +39,18 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("시트1")
                 .hasHeader(true)
                 .headerStartCell("A1")
                 .headerEndCell("G1")
-                .buildSerializer();
+                .buildDeserializer();
 
-        List<SetterTestClass> objects = serializer.serialize(SetterTestClass.class);
+        List<SetterTestClass> objects = deserializer.deserialize(SetterTestClass.class);
         assertNotNull(objects);
         Assertions.assertEquals(4, objects.size());
         System.out.println(objects);
-
     }
 
     @Test
@@ -58,14 +58,14 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_1line_content")
                 .hasHeader(true)
                 .headerStartCell("B4")
                 .headerEndCell("H4")
-                .buildSerializer();
-        List<NoSetterMultiLineHeaderTestClass> objects = serializer.serialize(NoSetterMultiLineHeaderTestClass.class);
+                .buildDeserializer();
+        List<NoSetterMultiLineHeaderTestClass> objects = deserializer.deserialize(NoSetterMultiLineHeaderTestClass.class);
         assertNotNull(objects);
         Assertions.assertEquals(4, objects.size());
         System.out.println(objects);
@@ -76,14 +76,14 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_1line_content")
                 .hasHeader(true)
                 .headerStartCell("B4")
                 .headerEndCell("H4")
-                .buildSerializer();
-        List<SetterMultiLineHeaderTestClass> objects = serializer.serialize(SetterMultiLineHeaderTestClass.class);
+                .buildDeserializer();
+        List<SetterMultiLineHeaderTestClass> objects = deserializer.deserialize(SetterMultiLineHeaderTestClass.class);
         assertNotNull(objects);
         Assertions.assertEquals(4, objects.size());
         System.out.println(objects);
@@ -94,14 +94,14 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_2line_content")
                 .hasHeader(true)
                 .headerStartCell("B3")
                 .headerEndCell("H4")
-                .buildSerializer();
-        List<NoSetterMultiLineHeaderMultiLineContentsTestClass> objects = serializer.serialize(NoSetterMultiLineHeaderMultiLineContentsTestClass.class);
+                .buildDeserializer();
+        List<NoSetterMultiLineHeaderMultiLineContentsTestClass> objects = deserializer.deserialize(NoSetterMultiLineHeaderMultiLineContentsTestClass.class);
         assertNotNull(objects);
         System.out.println(objects);
         Assertions.assertEquals(2, objects.size());
@@ -112,14 +112,14 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_2line_content")
                 .hasHeader(true)
                 .headerStartCell("B3")
                 .headerEndCell("H4")
-                .buildSerializer();
-        List<SetterMultiLineHeaderMultiLineContentsTestClass> objects = serializer.serialize(SetterMultiLineHeaderMultiLineContentsTestClass.class);
+                .buildDeserializer();
+        List<SetterMultiLineHeaderMultiLineContentsTestClass> objects = deserializer.deserialize(SetterMultiLineHeaderMultiLineContentsTestClass.class);
         assertNotNull(objects);
         System.out.println(objects);
         Assertions.assertEquals(2, objects.size());
@@ -130,15 +130,15 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_2line_content_2")
                 .hasHeader(true)
                 .headerStartCell("B3")
                 .headerEndCell("H4")
                 .contentsStartCell("B7")
-                .buildSerializer();
-        List<NoSetterMultiLineHeaderMultiLineContentsTestClass> objects = serializer.serialize(NoSetterMultiLineHeaderMultiLineContentsTestClass.class);
+                .buildDeserializer();
+        List<NoSetterMultiLineHeaderMultiLineContentsTestClass> objects = deserializer.deserialize(NoSetterMultiLineHeaderMultiLineContentsTestClass.class);
         assertNotNull(objects);
         System.out.println(objects);
         Assertions.assertEquals(2, objects.size());
@@ -149,18 +149,17 @@ class ExcelSerializerTest {
         Path resourceDirectory = Paths.get("src","test","resources", "xlsx", "test.xlsx");
         String absolutePath = resourceDirectory.toFile().getAbsolutePath();
 
-        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+        ExcelDeserializer deserializer = ExcelConverterBuilderFactory.create()
                 .excelFilePath(absolutePath)
                 .sheetName("2line_header_2line_content_2")
                 .hasHeader(true)
                 .headerStartCell("B3")
                 .headerEndCell("H4")
                 .contentsStartCell("B7")
-                .buildSerializer();
-        List<SetterMultiLineHeaderMultiLineContentsTestClass> objects = serializer.serialize(SetterMultiLineHeaderMultiLineContentsTestClass.class);
+                .buildDeserializer();
+        List<SetterMultiLineHeaderMultiLineContentsTestClass> objects = deserializer.deserialize(SetterMultiLineHeaderMultiLineContentsTestClass.class);
         assertNotNull(objects);
         System.out.println(objects);
         Assertions.assertEquals(2, objects.size());
     }
-
 }

--- a/src/test/java/io/github/jeng832/serializer/ExcelSerializerTest.java
+++ b/src/test/java/io/github/jeng832/serializer/ExcelSerializerTest.java
@@ -1,0 +1,241 @@
+package io.github.jeng832.serializer;
+
+import io.github.jeng832.annotation.ExcelProperty;
+import io.github.jeng832.converter.ExcelConverterBuilderFactory;
+import io.github.jeng832.exception.ExcelConvertException;
+import org.apache.poi.ss.usermodel.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ExcelSerializerTest {
+
+    @TempDir
+    Path tempDir;
+    private String testExcelPath;
+
+    @BeforeEach
+    void setUp() {
+        testExcelPath = tempDir.resolve("test.xlsx").toString();
+    }
+
+    @Test
+    void serialize_basic_types() throws ExcelConvertException, IOException {
+        // 테스트 데이터 준비
+        List<BasicTypesTestClass> objects = Arrays.asList(
+            new BasicTypesTestClass("홍길동", 30, 175.5, new Date(), true),
+            new BasicTypesTestClass("김철수", 25, 180.0, new Date(), false)
+        );
+
+        // Excel 파일 생성
+        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+                .excelFilePath(testExcelPath)
+                .sheetName("basic_types")
+                .hasHeader(true)
+                .headerStartCell("A1")
+                .buildSerializer();
+
+        serializer.serialize(objects, BasicTypesTestClass.class);
+
+        // 생성된 파일 검증
+        try (Workbook workbook = WorkbookFactory.create(new FileInputStream(testExcelPath))) {
+            Sheet sheet = workbook.getSheet("basic_types");
+            assertNotNull(sheet);
+
+            // 헤더 검증
+            Row headerRow = sheet.getRow(0);
+            assertEquals("이름", headerRow.getCell(0).getStringCellValue());
+            assertEquals("나이", headerRow.getCell(1).getStringCellValue());
+            assertEquals("키", headerRow.getCell(2).getStringCellValue());
+            assertEquals("생년월일", headerRow.getCell(3).getStringCellValue());
+            assertEquals("활성", headerRow.getCell(4).getStringCellValue());
+
+            // 데이터 검증
+            Row dataRow1 = sheet.getRow(1);
+            assertEquals("홍길동", dataRow1.getCell(0).getStringCellValue());
+            assertEquals(30, dataRow1.getCell(1).getNumericCellValue());
+            assertEquals(175.5, dataRow1.getCell(2).getNumericCellValue());
+            assertTrue(dataRow1.getCell(4).getBooleanCellValue());
+
+            Row dataRow2 = sheet.getRow(2);
+            assertEquals("김철수", dataRow2.getCell(0).getStringCellValue());
+            assertEquals(25, dataRow2.getCell(1).getNumericCellValue());
+            assertEquals(180.0, dataRow2.getCell(2).getNumericCellValue());
+            assertFalse(dataRow2.getCell(4).getBooleanCellValue());
+        }
+    }
+
+    @Test
+    void serialize_date_types() throws ExcelConvertException, IOException {
+        // 테스트 데이터 준비
+        List<DateTypesTestClass> objects = Arrays.asList(
+            new DateTypesTestClass(
+                new Date(),
+                LocalDate.now(),
+                LocalDateTime.now(),
+                ZonedDateTime.now()
+            )
+        );
+
+        // Excel 파일 생성
+        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+                .excelFilePath(testExcelPath)
+                .sheetName("date_types")
+                .hasHeader(true)
+                .headerStartCell("A1")
+                .buildSerializer();
+
+        serializer.serialize(objects, DateTypesTestClass.class);
+
+        // 생성된 파일 검증
+        try (Workbook workbook = WorkbookFactory.create(new FileInputStream(testExcelPath))) {
+            Sheet sheet = workbook.getSheet("date_types");
+            assertNotNull(sheet);
+
+            // 헤더 검증
+            Row headerRow = sheet.getRow(0);
+            assertEquals("Date", headerRow.getCell(0).getStringCellValue());
+            assertEquals("LocalDate", headerRow.getCell(1).getStringCellValue());
+            assertEquals("LocalDateTime", headerRow.getCell(2).getStringCellValue());
+            assertEquals("ZonedDateTime", headerRow.getCell(3).getStringCellValue());
+
+            // 데이터 검증
+            Row dataRow = sheet.getRow(1);
+            assertNotNull(dataRow.getCell(0).getDateCellValue());
+            assertNotNull(dataRow.getCell(1).getDateCellValue());
+            assertNotNull(dataRow.getCell(2).getDateCellValue());
+            assertNotNull(dataRow.getCell(3).getDateCellValue());
+        }
+    }
+
+    @Test
+    void serialize_empty_values() throws ExcelConvertException, IOException {
+        // 테스트 데이터 준비
+        List<EmptyValuesTestClass> objects = Arrays.asList(
+            new EmptyValuesTestClass(null, null, null, null)
+        );
+
+        // Excel 파일 생성
+        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+                .excelFilePath(testExcelPath)
+                .sheetName("empty_values")
+                .hasHeader(true)
+                .headerStartCell("A1")
+                .buildSerializer();
+
+        serializer.serialize(objects, EmptyValuesTestClass.class);
+
+        // 생성된 파일 검증
+        try (Workbook workbook = WorkbookFactory.create(new FileInputStream(testExcelPath))) {
+            Sheet sheet = workbook.getSheet("empty_values");
+            assertNotNull(sheet);
+
+            // 데이터 검증
+            Row dataRow = sheet.getRow(1);
+            assertEquals("", dataRow.getCell(0).getStringCellValue());
+            assertEquals("", dataRow.getCell(1).getStringCellValue());
+            assertEquals("", dataRow.getCell(2).getStringCellValue());
+            assertEquals("", dataRow.getCell(3).getStringCellValue());
+        }
+    }
+
+    @Test
+    void serialize_without_header() throws ExcelConvertException, IOException {
+        // 테스트 데이터 준비
+        List<BasicTypesTestClass> objects = Arrays.asList(
+            new BasicTypesTestClass("홍길동", 30, 175.5, new Date(), true)
+        );
+
+        // Excel 파일 생성
+        ExcelSerializer serializer = ExcelConverterBuilderFactory.create()
+                .excelFilePath(testExcelPath)
+                .sheetName("no_header")
+                .hasHeader(false)
+                .headerStartCell("A1")
+                .buildSerializer();
+
+        serializer.serialize(objects, BasicTypesTestClass.class);
+
+        // 생성된 파일 검증
+        try (Workbook workbook = WorkbookFactory.create(new FileInputStream(testExcelPath))) {
+            Sheet sheet = workbook.getSheet("no_header");
+            assertNotNull(sheet);
+
+            // 데이터만 있는지 확인
+            Row dataRow = sheet.getRow(0);
+            assertEquals("홍길동", dataRow.getCell(0).getStringCellValue());
+            assertEquals(30, dataRow.getCell(1).getNumericCellValue());
+            assertEquals(175.5, dataRow.getCell(2).getNumericCellValue());
+            assertTrue(dataRow.getCell(4).getBooleanCellValue());
+        }
+    }
+
+    // 테스트용 클래스들
+    public static class BasicTypesTestClass {
+        @ExcelProperty("이름")
+        private String name;
+        @ExcelProperty("나이")
+        private Integer age;
+        @ExcelProperty("키")
+        private Double height;
+        @ExcelProperty("생년월일")
+        private Date birthDate;
+        @ExcelProperty("활성")
+        private Boolean active;
+
+        public BasicTypesTestClass(String name, Integer age, Double height, Date birthDate, Boolean active) {
+            this.name = name;
+            this.age = age;
+            this.height = height;
+            this.birthDate = birthDate;
+            this.active = active;
+        }
+    }
+
+    public static class DateTypesTestClass {
+        @ExcelProperty("Date")
+        private Date date;
+        @ExcelProperty("LocalDate")
+        private LocalDate localDate;
+        @ExcelProperty("LocalDateTime")
+        private LocalDateTime localDateTime;
+        @ExcelProperty("ZonedDateTime")
+        private ZonedDateTime zonedDateTime;
+
+        public DateTypesTestClass(Date date, LocalDate localDate, LocalDateTime localDateTime, ZonedDateTime zonedDateTime) {
+            this.date = date;
+            this.localDate = localDate;
+            this.localDateTime = localDateTime;
+            this.zonedDateTime = zonedDateTime;
+        }
+    }
+
+    public static class EmptyValuesTestClass {
+        @ExcelProperty("문자열")
+        private String stringValue;
+        @ExcelProperty("숫자")
+        private Integer numberValue;
+        @ExcelProperty("날짜")
+        private Date dateValue;
+        @ExcelProperty("불리언")
+        private Boolean booleanValue;
+
+        public EmptyValuesTestClass(String stringValue, Integer numberValue, Date dateValue, Boolean booleanValue) {
+            this.stringValue = stringValue;
+            this.numberValue = numberValue;
+            this.dateValue = dateValue;
+            this.booleanValue = booleanValue;
+        }
+    }
+} 


### PR DESCRIPTION
- ExcelConverter를 ExcelSerializer와 ExcelDeserializer로 분리

- 버전을 1.0.0-candidate로 업데이트

- 테스트 코드 재구성 및 개선

- 예외 메시지 추가